### PR TITLE
Refactor EditorViewModel

### DIFF
--- a/editor/src/main/java/com/github/kitakkun/noteapp/editor/EditorModule.kt
+++ b/editor/src/main/java/com/github/kitakkun/noteapp/editor/EditorModule.kt
@@ -1,6 +1,7 @@
 package com.github.kitakkun.noteapp.editor
 
 import androidx.navigation.NavController
+import com.github.kitakkun.noteapp.editor.usecase.AnchorTransformer
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
@@ -13,7 +14,9 @@ val editorModule = module {
             navController = navController,
             historyManager = get(),
             settingDataStore = get(),
+            anchorTransformer = get(),
         )
     }
     factoryOf(::EditHistoryManager)
+    factoryOf(::AnchorTransformer)
 }

--- a/editor/src/main/java/com/github/kitakkun/noteapp/editor/EditorViewModel.kt
+++ b/editor/src/main/java/com/github/kitakkun/noteapp/editor/EditorViewModel.kt
@@ -30,7 +30,7 @@ class EditorViewModel(
     private val documentRepository: DocumentRepository,
     private val settingDataStore: SettingDataStore,
     private val navController: NavController,
-    private val historyManager: com.github.kitakkun.noteapp.editor.EditHistoryManager,
+    private val historyManager: EditHistoryManager,
     private val anchorTransformer: AnchorTransformer,
 ) : ViewModel() {
     companion object {

--- a/editor/src/main/java/com/github/kitakkun/noteapp/editor/EditorViewModel.kt
+++ b/editor/src/main/java/com/github/kitakkun/noteapp/editor/EditorViewModel.kt
@@ -15,6 +15,8 @@ import com.github.kitakkun.noteapp.data.store.SettingDataStore
 import com.github.kitakkun.noteapp.editor.editmodel.EditHistory
 import com.github.kitakkun.noteapp.editor.editmodel.EditorConfig
 import com.github.kitakkun.noteapp.editor.editmodel.TextFieldChangeEvent
+import com.github.kitakkun.noteapp.editor.ext.getLineAtEndCursor
+import com.github.kitakkun.noteapp.editor.ext.getLineAtStartCursor
 import com.github.kitakkun.noteapp.editor.usecase.AnchorTransformer
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -328,20 +330,6 @@ class EditorViewModel(
             isItalic = activeOverrideAnchors.any { it.style is OverrideStyle.Italic },
             color = (activeOverrideAnchors.find { it.style is OverrideStyle.Color }?.style as? OverrideStyle.Color)?.color ?: editorConfig.color
         )
-    }
-
-    private fun TextFieldValue.getLineAtStartCursor(): Int {
-        val cursorPosition = this.selection.start
-        if (cursorPosition == 0) return 0
-        val textBeforeCursor = this.text.substring(0, cursorPosition)
-        return textBeforeCursor.count { it == '\n' }
-    }
-
-    private fun TextFieldValue.getLineAtEndCursor(): Int {
-        val cursorPosition = this.selection.end
-        if (cursorPosition == 0) return 0
-        val textBeforeCursor = this.text.substring(0, cursorPosition)
-        return textBeforeCursor.count { it == '\n' }
     }
 
     fun redo() {

--- a/editor/src/main/java/com/github/kitakkun/noteapp/editor/EditorViewModel.kt
+++ b/editor/src/main/java/com/github/kitakkun/noteapp/editor/EditorViewModel.kt
@@ -1,6 +1,5 @@
 package com.github.kitakkun.noteapp.editor
 
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -16,13 +15,7 @@ import com.github.kitakkun.noteapp.data.store.SettingDataStore
 import com.github.kitakkun.noteapp.editor.editmodel.EditHistory
 import com.github.kitakkun.noteapp.editor.editmodel.EditorConfig
 import com.github.kitakkun.noteapp.editor.editmodel.TextFieldChangeEvent
-import com.github.kitakkun.noteapp.editor.ext.deleteLinesAndShiftUp
-import com.github.kitakkun.noteapp.editor.ext.insertNewAnchorsAndShiftDown
-import com.github.kitakkun.noteapp.editor.ext.optimize
-import com.github.kitakkun.noteapp.editor.ext.shiftToLeft
-import com.github.kitakkun.noteapp.editor.ext.shiftToRight
-import com.github.kitakkun.noteapp.editor.ext.splitAt
-import com.github.kitakkun.noteapp.editor.ext.toValidOrder
+import com.github.kitakkun.noteapp.editor.usecase.AnchorTransformer
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -38,6 +31,7 @@ class EditorViewModel(
     private val settingDataStore: SettingDataStore,
     private val navController: NavController,
     private val historyManager: com.github.kitakkun.noteapp.editor.EditHistoryManager,
+    private val anchorTransformer: AnchorTransformer,
 ) : ViewModel() {
     companion object {
         private const val TAG = "EditorViewModel"
@@ -152,13 +146,13 @@ class EditorViewModel(
             new = newTextFieldValue,
         )
 
-        val newOverrideAnchors = updateOverrideAnchors(
+        val newOverrideAnchors = anchorTransformer.updateOverrideAnchors(
             event = event,
             anchors = uiState.value.overrideStyleAnchors,
             editorConfig = oldEditorConfig,
         )
 
-        val newBaseStyleAnchors = updateBaseStyleAnchors(
+        val newBaseStyleAnchors = anchorTransformer.updateBaseStyleAnchors(
             oldAnchors = uiState.value.baseStyleAnchors,
             insertCursorLine = oldTextFieldValue.getLineAtStartCursor(),
             lineCount = newTextFieldValue.text.lines().size,
@@ -206,7 +200,8 @@ class EditorViewModel(
         mutableUiState.update {
             it.copy(
                 editorConfig = it.editorConfig.copy(isBold = toggledIsBold),
-                overrideStyleAnchors = toggleOverrideStyleOfSelection(
+                overrideStyleAnchors = anchorTransformer.toggleOverrideStyleOfSelection(
+                    currentAnchors = it.overrideStyleAnchors,
                     selection = it.content.selection,
                     overrideStyle = OverrideStyle.Bold(toggledIsBold),
                     overrideAnchors = it.overrideStyleAnchors,
@@ -231,7 +226,8 @@ class EditorViewModel(
         mutableUiState.update {
             it.copy(
                 editorConfig = it.editorConfig.copy(isItalic = toggledIsItalic),
-                overrideStyleAnchors = toggleOverrideStyleOfSelection(
+                overrideStyleAnchors = anchorTransformer.toggleOverrideStyleOfSelection(
+                    currentAnchors = it.overrideStyleAnchors,
                     selection = it.content.selection,
                     overrideStyle = OverrideStyle.Italic(toggledIsItalic),
                     overrideAnchors = it.overrideStyleAnchors,
@@ -278,7 +274,8 @@ class EditorViewModel(
                 editorConfig = uiState.editorConfig.copy(
                     color = color,
                 ),
-                overrideStyleAnchors = toggleOverrideStyleOfSelection(
+                overrideStyleAnchors = anchorTransformer.toggleOverrideStyleOfSelection(
+                    currentAnchors = uiState.overrideStyleAnchors,
                     selection = uiState.content.selection,
                     overrideStyle = OverrideStyle.Color(color),
                     overrideAnchors = uiState.overrideStyleAnchors,
@@ -315,128 +312,6 @@ class EditorViewModel(
         mutableUiState.update { it.copy(showSelectBaseStyleDialog = false) }
     }
 
-    /**
-     * update override style anchors
-     * @param event [TextFieldValue] change event
-     * @param anchors current override style anchors
-     * @param editorConfig active editor configuration
-     */
-    private fun updateOverrideAnchors(
-        event: TextFieldChangeEvent,
-        anchors: List<OverrideStyleAnchor>,
-        editorConfig: EditorConfig,
-    ) = when (event) {
-        is TextFieldChangeEvent.Insert -> {
-            anchors
-                .splitAt(event.position)
-                .shiftToRight(
-                    baseOffset = event.position,
-                    shiftOffset = event.length,
-                ) + generateAnchorsToInsert(
-                editorConfig = editorConfig,
-                insertPos = event.position,
-                length = event.length,
-            )
-        }
-
-        is TextFieldChangeEvent.Delete -> {
-            anchors.shiftToLeft(
-                baseOffset = event.position,
-                shiftOffset = event.length,
-            )
-        }
-
-        is TextFieldChangeEvent.Replace -> {
-            anchors
-                // 選択部分の削除
-                .splitAt(event.oldValue.selection.start)
-                .splitAt(event.oldValue.selection.end)
-                .filterNot { it.start in event.oldValue.selection && it.end in event.oldValue.selection }
-                .shiftToLeft(
-                    baseOffset = event.position,
-                    shiftOffset = event.deletedText.length,
-                )
-                .shiftToRight(
-                    baseOffset = event.position,
-                    shiftOffset = event.insertedText.length,
-                )
-        }
-
-        else -> anchors
-    }.filter { it.isValid() }.optimize()
-
-    private fun updateBaseStyleAnchors(
-        oldAnchors: List<BaseStyleAnchor>,
-        insertCursorLine: Int,
-        lineCount: Int,
-        event: TextFieldChangeEvent,
-        insertionBaseStyle: BaseStyle,
-    ) = when (event) {
-        is TextFieldChangeEvent.Insert -> {
-            oldAnchors.insertNewAnchorsAndShiftDown(
-                baseStyle = insertionBaseStyle,
-                insertCursorLine = insertCursorLine,
-                insertLines = event.insertedText.count { it == '\n' }
-            )
-        }
-
-        is TextFieldChangeEvent.Delete -> {
-            oldAnchors.deleteLinesAndShiftUp(
-                deleteCursorLine = insertCursorLine,
-                deleteLines = event.deletedText.count { it == '\n' }
-            )
-        }
-
-        is TextFieldChangeEvent.Replace -> {
-            oldAnchors
-                .deleteLinesAndShiftUp(
-                    deleteCursorLine = insertCursorLine,
-                    deleteLines = event.deletedText.count { it == '\n' }
-                )
-                .insertNewAnchorsAndShiftDown(
-                    baseStyle = insertionBaseStyle,
-                    insertCursorLine = insertCursorLine,
-                    insertLines = event.insertedText.count { it == '\n' }
-                )
-        }
-
-        else -> oldAnchors
-    }.filter { it.isValid(lineCount) }.distinctBy { it.line }
-
-    private fun generateAnchorsToInsert(
-        editorConfig: EditorConfig,
-        insertPos: Int,
-        length: Int,
-    ): List<OverrideStyleAnchor> {
-        val anchorsToInsert = mutableListOf<OverrideStyleAnchor>()
-        if (editorConfig.isBold) {
-            anchorsToInsert.add(
-                OverrideStyleAnchor(
-                    start = insertPos,
-                    end = insertPos + length,
-                    style = OverrideStyle.Bold(true),
-                )
-            )
-        }
-        if (editorConfig.isItalic) {
-            anchorsToInsert.add(
-                OverrideStyleAnchor(
-                    start = insertPos,
-                    end = insertPos + length,
-                    style = OverrideStyle.Italic(true),
-                )
-            )
-        }
-        anchorsToInsert.add(
-            OverrideStyleAnchor(
-                start = insertPos,
-                end = insertPos + length,
-                style = OverrideStyle.Color(editorConfig.color),
-            )
-        )
-        return anchorsToInsert
-    }
-
     private fun recalculateEditorConfig(
         editorConfig: EditorConfig,
         cursorPos: Int,
@@ -453,30 +328,6 @@ class EditorViewModel(
             isItalic = activeOverrideAnchors.any { it.style is OverrideStyle.Italic },
             color = (activeOverrideAnchors.find { it.style is OverrideStyle.Color }?.style as? OverrideStyle.Color)?.color ?: editorConfig.color
         )
-    }
-
-    private fun toggleOverrideStyleOfSelection(
-        selection: TextRange,
-        overrideStyle: OverrideStyle,
-        overrideAnchors: List<OverrideStyleAnchor>,
-    ): List<OverrideStyleAnchor> {
-        if (selection.collapsed) return overrideAnchors
-        val orderedSelection = selection.toValidOrder()
-        val newAnchors = uiState.value.overrideStyleAnchors
-            .splitAt(orderedSelection.start)
-            .splitAt(orderedSelection.end)
-            .filterNot {
-                (it.start >= orderedSelection.start)
-                    && (it.end <= orderedSelection.end)
-                    && (it.style::class == overrideStyle::class)
-            } + listOf(
-            OverrideStyleAnchor(
-                start = orderedSelection.start,
-                end = orderedSelection.end,
-                style = overrideStyle,
-            )
-        )
-        return newAnchors
     }
 
     private fun TextFieldValue.getLineAtStartCursor(): Int {

--- a/editor/src/main/java/com/github/kitakkun/noteapp/editor/ext/TextFIeldValue.kt
+++ b/editor/src/main/java/com/github/kitakkun/noteapp/editor/ext/TextFIeldValue.kt
@@ -1,0 +1,18 @@
+package com.github.kitakkun.noteapp.editor.ext
+
+import androidx.compose.ui.text.input.TextFieldValue
+
+fun TextFieldValue.getLineAtStartCursor(): Int {
+    val cursorPosition = this.selection.start
+    if (cursorPosition == 0) return 0
+    val textBeforeCursor = this.text.substring(0, cursorPosition)
+    return textBeforeCursor.count { it == '\n' }
+}
+
+fun TextFieldValue.getLineAtEndCursor(): Int {
+    val cursorPosition = this.selection.end
+    if (cursorPosition == 0) return 0
+    val textBeforeCursor = this.text.substring(0, cursorPosition)
+    return textBeforeCursor.count { it == '\n' }
+}
+

--- a/editor/src/main/java/com/github/kitakkun/noteapp/editor/usecase/AnchorTransformer.kt
+++ b/editor/src/main/java/com/github/kitakkun/noteapp/editor/usecase/AnchorTransformer.kt
@@ -1,0 +1,167 @@
+package com.github.kitakkun.noteapp.editor.usecase
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import com.github.kitakkun.noteapp.data.model.BaseStyle
+import com.github.kitakkun.noteapp.data.model.BaseStyleAnchor
+import com.github.kitakkun.noteapp.data.model.OverrideStyle
+import com.github.kitakkun.noteapp.data.model.OverrideStyleAnchor
+import com.github.kitakkun.noteapp.editor.editmodel.EditorConfig
+import com.github.kitakkun.noteapp.editor.editmodel.TextFieldChangeEvent
+import com.github.kitakkun.noteapp.editor.ext.deleteLinesAndShiftUp
+import com.github.kitakkun.noteapp.editor.ext.insertNewAnchorsAndShiftDown
+import com.github.kitakkun.noteapp.editor.ext.optimize
+import com.github.kitakkun.noteapp.editor.ext.shiftToLeft
+import com.github.kitakkun.noteapp.editor.ext.shiftToRight
+import com.github.kitakkun.noteapp.editor.ext.splitAt
+import com.github.kitakkun.noteapp.editor.ext.toValidOrder
+
+class AnchorTransformer {
+    /**
+     * update override style anchors
+     * @param event [TextFieldValue] change event
+     * @param anchors current override style anchors
+     * @param editorConfig active editor configuration
+     */
+    fun updateOverrideAnchors(
+        event: TextFieldChangeEvent,
+        anchors: List<OverrideStyleAnchor>,
+        editorConfig: EditorConfig,
+    ) = when (event) {
+        is TextFieldChangeEvent.Insert -> {
+            anchors
+                .splitAt(event.position)
+                .shiftToRight(
+                    baseOffset = event.position,
+                    shiftOffset = event.length,
+                ) + generateAnchorsToInsert(
+                editorConfig = editorConfig,
+                insertPos = event.position,
+                length = event.length,
+            )
+        }
+
+        is TextFieldChangeEvent.Delete -> {
+            anchors.shiftToLeft(
+                baseOffset = event.position,
+                shiftOffset = event.length,
+            )
+        }
+
+        is TextFieldChangeEvent.Replace -> {
+            anchors
+                // 選択部分の削除
+                .splitAt(event.oldValue.selection.start)
+                .splitAt(event.oldValue.selection.end)
+                .filterNot { it.start in event.oldValue.selection && it.end in event.oldValue.selection }
+                .shiftToLeft(
+                    baseOffset = event.position,
+                    shiftOffset = event.deletedText.length,
+                )
+                .shiftToRight(
+                    baseOffset = event.position,
+                    shiftOffset = event.insertedText.length,
+                )
+        }
+
+        else -> anchors
+    }.filter { it.isValid() }.optimize()
+
+    private fun generateAnchorsToInsert(
+        editorConfig: EditorConfig,
+        insertPos: Int,
+        length: Int,
+    ): List<OverrideStyleAnchor> {
+        val anchorsToInsert = mutableListOf<OverrideStyleAnchor>()
+        if (editorConfig.isBold) {
+            anchorsToInsert.add(
+                OverrideStyleAnchor(
+                    start = insertPos,
+                    end = insertPos + length,
+                    style = OverrideStyle.Bold(true),
+                )
+            )
+        }
+        if (editorConfig.isItalic) {
+            anchorsToInsert.add(
+                OverrideStyleAnchor(
+                    start = insertPos,
+                    end = insertPos + length,
+                    style = OverrideStyle.Italic(true),
+                )
+            )
+        }
+        anchorsToInsert.add(
+            OverrideStyleAnchor(
+                start = insertPos,
+                end = insertPos + length,
+                style = OverrideStyle.Color(editorConfig.color),
+            )
+        )
+        return anchorsToInsert
+    }
+
+
+    fun updateBaseStyleAnchors(
+        oldAnchors: List<BaseStyleAnchor>,
+        insertCursorLine: Int,
+        lineCount: Int,
+        event: TextFieldChangeEvent,
+        insertionBaseStyle: BaseStyle,
+    ) = when (event) {
+        is TextFieldChangeEvent.Insert -> {
+            oldAnchors.insertNewAnchorsAndShiftDown(
+                baseStyle = insertionBaseStyle,
+                insertCursorLine = insertCursorLine,
+                insertLines = event.insertedText.count { it == '\n' }
+            )
+        }
+
+        is TextFieldChangeEvent.Delete -> {
+            oldAnchors.deleteLinesAndShiftUp(
+                deleteCursorLine = insertCursorLine,
+                deleteLines = event.deletedText.count { it == '\n' }
+            )
+        }
+
+        is TextFieldChangeEvent.Replace -> {
+            oldAnchors
+                .deleteLinesAndShiftUp(
+                    deleteCursorLine = insertCursorLine,
+                    deleteLines = event.deletedText.count { it == '\n' }
+                )
+                .insertNewAnchorsAndShiftDown(
+                    baseStyle = insertionBaseStyle,
+                    insertCursorLine = insertCursorLine,
+                    insertLines = event.insertedText.count { it == '\n' }
+                )
+        }
+
+        else -> oldAnchors
+    }.filter { it.isValid(lineCount) }.distinctBy { it.line }
+
+    fun toggleOverrideStyleOfSelection(
+        currentAnchors: List<OverrideStyleAnchor>,
+        selection: TextRange,
+        overrideStyle: OverrideStyle,
+        overrideAnchors: List<OverrideStyleAnchor>,
+    ): List<OverrideStyleAnchor> {
+        if (selection.collapsed) return overrideAnchors
+        val orderedSelection = selection.toValidOrder()
+        val newAnchors = currentAnchors
+            .splitAt(orderedSelection.start)
+            .splitAt(orderedSelection.end)
+            .filterNot {
+                (it.start >= orderedSelection.start)
+                    && (it.end <= orderedSelection.end)
+                    && (it.style::class == overrideStyle::class)
+            } + listOf(
+            OverrideStyleAnchor(
+                start = orderedSelection.start,
+                end = orderedSelection.end,
+                style = overrideStyle,
+            )
+        )
+        return newAnchors
+    }
+}


### PR DESCRIPTION
## Overview
Placing anchor transformation logic inside EditorViewModel causes too much complexity.
Moving inner logic into external class will partially resolve this issue.