### PR TITLE
[Fix] Can't open old documents

### DIFF
--- a/data/src/main/java/com/github/kitakkun/noteapp/data/model/BaseStyleAnchor.kt
+++ b/data/src/main/java/com/github/kitakkun/noteapp/data/model/BaseStyleAnchor.kt
@@ -1,12 +1,14 @@
 package com.github.kitakkun.noteapp.data.model
 
+import com.google.gson.annotations.SerializedName
+
 /**
  * Represents a anchor for BaseStyle.
  * @param lineNumber 0-indexed line number
  * @style style to apply to the line
  */
 data class BaseStyleAnchor(
-    val lineNumber: Int,
+    @SerializedName("line", alternate = ["lineNumber"]) val lineNumber: Int,
     val style: BaseStyle,
 ) {
     fun isValid(lineCount: Int) = lineNumber in 0 until lineCount


### PR DESCRIPTION
After PR #28 was merged, old documents were no longer able to be opened.

This commit changes a field name, "line" into "lineNumber," and this caused the problem.
[refactor: rename line to lineNumber](https://github.com/kitakkun/JotDraft/pull/28/commits/644ca72da1eee2637fcb60107aa8b531cdd22451)

To fix this issue, added `@SerializedName` to `lineNumber` field.